### PR TITLE
grunt-contrib-sass duplicated dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   },
   "dependencies": {
     "dropbox": "^0.10.3",
-    "grunt-contrib-sass": "^0.9.2",
     "lowdb": "^0.10.0",
     "merge": "^1.2.0",
     "path": "^0.11.14",


### PR DESCRIPTION
I've got this warning from npm today while installing Ohm:

```
npm WARN package.json Dependency 'grunt-contrib-sass' exists in both dependencies and devDependencies, using 'grunt-contrib-sass@^0.9.2' from dependencies
```

This PR removes the duplicated dependency.
